### PR TITLE
Copy the service labels also to Deployment Pod spec annotations

### DIFF
--- a/pkg/transformer/kubernetes/kubernetes.go
+++ b/pkg/transformer/kubernetes/kubernetes.go
@@ -303,6 +303,9 @@ func (k *Kubernetes) InitD(name string, service kobject.ServiceConfig, replicas 
 		Spec: extensions.DeploymentSpec{
 			Replicas: int32(replicas),
 			Template: api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Annotations: transformer.ConfigAnnotations(service),
+				},
 				Spec: podSpec,
 			},
 		},


### PR DESCRIPTION
Isso produz os labels do docker-compose.yml também no Deployment como templete do Pod. Necessário para o kube2iam funcionar.

Vai gerar a parte `spec.template.metadata.annotations` do arquivo XX-deployment.yaml, que antes não existia:
```yaml
$ cat service-name-deployment.yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  annotations:
    iam.amazonaws.com/role: '{{ SERVICE_NAME }}-{{ ENV }}-role'
    kompose.cmd: kompose convert -v
    kompose.version: 1.18.0 (HEAD)
  creationTimestamp: null
  labels:
    io.kompose.service: service-name
  name: service-name
spec:
  replicas: 1
  strategy: {}
  template:
    metadata:
      annotations:
        iam.amazonaws.com/role: '{{ SERVICE_NAME }}-{{ ENV }}-role'
        kompose.cmd: kompose convert -v
        kompose.version: 1.18.0 (HEAD)
      creationTimestamp: null
      labels:
        io.kompose.service: service-name
    spec:
      containers:
      - image: CURRENT_BUILD
        name: service-name
        ports:
        - containerPort: 1234
        resources: {}
      restartPolicy: Always
status: {}
```